### PR TITLE
Making path available inside the scope of the macro

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,10 +4,12 @@ authors = ["Átila Saraiva Quintela Soares"]
 version = "0.1.0"
 
 [deps]
+MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
 [compat]
 julia = "1.10"
+MacroTools = "0.5"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/Flow.jl
+++ b/src/Flow.jl
@@ -1,6 +1,7 @@
 module Flow
 
 using SHA: sha256
+using MacroTools: postwalk
 
 include("flow.jl")
 

--- a/src/flow.jl
+++ b/src/flow.jl
@@ -15,6 +15,7 @@ function checkFileExists(path, sha256sum)
 end
 
 function flow(path::Expr, expr::Expr)
+    newExpr = postwalk(x -> x == :path ? path.args[2] : x, expr)
     return quote
        filePath = $(esc(path.args[2]))
        hash_file = filePath * ".hash"
@@ -31,7 +32,7 @@ function flow(path::Expr, expr::Expr)
        end
 
        if flag
-           $(esc(expr))
+           $(esc(newExpr))
 
            # Compute new hash and save it
            new_hash = open(filePath) do io

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,10 +4,12 @@ using Test
 @testset "Flow.jl" begin
     counter = 1
 
+    path = "this should not change"
+
     filePath, _ = mktemp()
     @flow path=filePath begin
         counter += 1
-        write(filePath, "oi1")
+        write(path, "oi1")
     end
 
     @flow path=filePath begin
@@ -18,4 +20,5 @@ using Test
     rm(filePath * ".hash")
 
     @test counter == 2
+    @test path == "this should not change"
 end


### PR DESCRIPTION
This used to be a feature, but I changed the implementation of the macro to be more pure, i.e. now it is just giving back an expression instead of doing computations.